### PR TITLE
Add a bunch more specs and fix some bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+/.rspec_status

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Style/Documentation:
     - 'spec/**/*'
     - 'lib/blobby/gcs_store.rb'
 
+Style/DoubleNegation:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - '**/*.gemspec'

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # Blobby::GCSStore [![Build status](https://badge.buildkite.com/3a10d87beff89aab18d733ccd5fb3080e76020079c00ebdaab.svg)](https://buildkite.com/gs/blobby-gcs)
 
-This gem provides an GCS-based implementation of the "store" interface defined by the ["blobby"](https://github.com/realestate-com-au/blobby) gem.  It's been packaged separately, to avoid adding dependencies to the core gem.
+This gem provides a Google Cloud Storage (GCS) implementation of the "store" interface defined by the [`blobby`](https://github.com/realestate-com-au/blobby) gem. It's been packaged separately to avoid adding dependencies to the core gem.
 
 The simplest use-case is writing to a single bucket:
 
-    gcs_store = Blobby.store("gs://<bucket_name>/<file_path_inside_bucket>")
-    gcs_store["key"].write("IO containing a file")
-
-We recommend that you provide credentials using [environment variables](https://googleapis.dev/ruby/google-cloud-storage/latest/file.AUTHENTICATION.html)
-
+```ruby
+gcs_store = Blobby.store("gs://<bucket_name>/<directory_path_inside_bucket>")
+gcs_store["key"].write("IO or string file content")
 ```
-    require 'blobby-gcs'
 
-    ENV["GOOGLE_CLOUD_PROJECT"]     = "my-project-id"
-    ENV["GOOGLE_APPLICATION_CREDENTIALS"] = "path/to/keyfile.json"
+Configuration is provided using the [same environment variables](https://googleapis.dev/ruby/google-cloud-storage/latest/file.AUTHENTICATION.html) as the `google-cloud-storage` gem (which this one is wrapping).
 
-    gcs_store = Blobby.store("gs://<bucket_name>/<file_path_inside_bucket>")
+```ruby
+require 'blobby-gcs'
+
+ENV["GOOGLE_CLOUD_PROJECT"] = "my-project-id"
+ENV["GOOGLE_APPLICATION_CREDENTIALS"] = "path/to/keyfile.json"
+
+gcs_store = Blobby.store("gs://<bucket_name>/<directory_path_inside_bucket>")
 ```
 
 ## Installation
@@ -28,25 +30,29 @@ gem 'blobby-gcs'
 
 And then execute:
 
-    $ bundle
+```bash
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install blobby-gcs
+```
+$ gem install blobby-gcs
+```
 
 ## Development
 
 You can run the tests within docker via `auto/test` or directly within your shell using `scripts/test`.
 
-The tests within this gem are pointing to the real **Google Cloud Store** as integration tests so you will need to provide credentials, if you have authenticated via [gcloud](https://cloud.google.com/sdk/gcloud/) you may already have credentials available when using `scripts/test`. If you are using docker then you will need to provide the credentials:
+There are integration tests within this gem which point to a real **Google Cloud Storage** bucket, so you will need to provide credentials. If you have authenticated via [`gcloud`](https://cloud.google.com/sdk/gcloud/), you may already have credentials available when using `scripts/test`. If you are using Docker, then you will need to provide the credentials:
 
-```
+```bash
 export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
-
 export GOOGLE_CLOUD_PROJECT=...name of project...
+export BLOBBY_GCS_TEST_BUCKET=...a bucket you have storage.objectAdmin access to...
 ```
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and publish the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are integration tests within this gem which point to a real **Google Cloud
 $ gcloud auth application-default login
 ```
 
-You will also need to provide the name of a GCS bucket you have `storage.objectAdmin` access to:
+You will also need to provide the name of a GCS bucket you have `storage.objectAdmin` access to (and unfortunately, also `storage.legacyBucketReader`):
 
 ```bash
 export GOOGLE_CLOUD_PROJECT=unused

--- a/README.md
+++ b/README.md
@@ -36,20 +36,25 @@ $ bundle
 
 Or install it yourself as:
 
-```
+```bash
 $ gem install blobby-gcs
 ```
 
 ## Development
 
-You can run the tests within docker via `auto/test` or directly within your shell using `scripts/test`.
+You can run the tests within Docker via `auto/test` or directly within your shell using `scripts/test`.
 
-There are integration tests within this gem which point to a real **Google Cloud Storage** bucket, so you will need to provide credentials. If you have authenticated via [`gcloud`](https://cloud.google.com/sdk/gcloud/), you may already have credentials available when using `scripts/test`. If you are using Docker, then you will need to provide the credentials:
+There are integration tests within this gem which point to a real **Google Cloud Storage** bucket, so credentials are required. If you do not already have `~/.config/gcloud/application_default_credentials.json` from authenticating with [`gcloud`](https://cloud.google.com/sdk/gcloud/), run:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/application_default_credentials.json
-export GOOGLE_CLOUD_PROJECT=...name of project...
-export BLOBBY_GCS_TEST_BUCKET=...a bucket you have storage.objectAdmin access to...
+$ gcloud auth application-default login
+```
+
+You will also need to provide the name of a GCS bucket you have `storage.objectAdmin` access to:
+
+```bash
+export GOOGLE_CLOUD_PROJECT=unused
+export BLOBBY_GCS_TEST_BUCKET=...name of bucket...
 ```
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and publish the `.gem` file to [rubygems.org](https://rubygems.org).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,14 @@ services:
       - .:/work
       - ruby-2.6.3-gem-cache:/usr/local/bundle
       - rubocop-cache:/work/.cache/rubocop_cache
-      - "${GOOGLE_APPLICATION_CREDENTIALS-}:${GOOGLE_APPLICATION_CREDENTIALS-}:ro"
+      - "${GOOGLE_APPLICATION_CREDENTIALS-~/.config/gcloud/application_default_credentials.json}:/secrets/gcloud/credentials.json:ro"
     working_dir: /work
     entrypoint: /work/scripts/bundle-exec
     command: bash
     environment:
-      GOOGLE_APPLICATION_CREDENTIALS: "${GOOGLE_APPLICATION_CREDENTIALS-}"
-      STORAGE_PROJECT: "${GOOGLE_CLOUD_PROJECT-}"
+      GOOGLE_APPLICATION_CREDENTIALS: /secrets/gcloud/credentials.json
+      GOOGLE_CLOUD_PROJECT: unused
+      GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS: 'true'
 
 volumes:
   ruby-2.6.3-gem-cache: ~

--- a/lib/blobby/gcs_store.rb
+++ b/lib/blobby/gcs_store.rb
@@ -29,7 +29,7 @@ module Blobby
     end
 
     def available?
-      bucket.exists?
+      !!bucket&.exists?
     end
 
     def [](key)
@@ -47,14 +47,14 @@ module Blobby
       # https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/File.html#exists%3F-instance_method
       # bucket.file(key) returns nil, if the file does not exist!
       def exists?
-        gcs_file.nil? ? false : gcs_file.exists?
+        !!gcs_file&.exists?
       end
 
       # https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/File.html#download-instance_method
       def read
         return nil unless exists?
 
-        content = gcs_file.download
+        content = gcs_file.download.read
         if block_given?
           yield content
           nil
@@ -65,6 +65,7 @@ module Blobby
 
       # https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/Bucket.html#create_file-instance_method
       def write(content)
+        content = StringIO.new(content) unless content.respond_to?(:read)
         bucket.create_file(content, key)
         nil
       end
@@ -81,7 +82,7 @@ module Blobby
       attr_reader :bucket, :key
 
       def gcs_file
-        @gcs_file ||= bucket.file(key)
+        bucket.file(key)
       end
 
     end

--- a/lib/blobby/gcs_store.rb
+++ b/lib/blobby/gcs_store.rb
@@ -94,7 +94,7 @@ module Blobby
     attr_reader :bucket_name, :gcs_options
 
     def bucket
-      @bucket ||= gcs_client.bucket(bucket_name)
+      @bucket ||= gcs_client.bucket(bucket_name, skip_lookup: true)
     end
 
     def gcs_client

--- a/lib/blobby/gcs_store.rb
+++ b/lib/blobby/gcs_store.rb
@@ -54,12 +54,14 @@ module Blobby
       def read
         return nil unless exists?
 
-        content = gcs_file.download.read
+        io = gcs_file.download
         if block_given?
-          yield content
+          while (chunk = io.read(512))
+            yield chunk
+          end
           nil
         else
-          content
+          io.read
         end
       end
 

--- a/scripts/bundle-exec
+++ b/scripts/bundle-exec
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-gem install bundler:2.1.0
+gem list bundler -iev 2.1.0 > /dev/null || gem install bundler:2.1.0
 
 bundle check || bundle install
 exec bundle exec "${@-bash}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'blobby/gcs'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
-
-  # Disable RSpec exposing methods globally on `Module` and `main`
-  config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
Changes include:

- Editorial improvements to the readme
- Testing more thoroughly by including shared examples from Blobby's specs, as used in [blobby-s3](https://github.com/realestate-com-au/blobby-s3/blob/master/spec/blobby/s3_store_spec.rb). I had to remove the disabling of RSpec's top-level monkey-patching in order to use this without modification
- Fixing write not writing the content, but instead trying to copy a file with that name
- Making read return a string rather than a StringIO to better match Blobby's expected interface
- Fixing existence methods for unhappy paths
- Fixing re-reading a file after updating it