### PR TITLE
Transition away from GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/scripts/bundle-exec
+++ b/scripts/bundle-exec
@@ -6,6 +6,10 @@ else
   echo ".docker-bashrc not found - see https://handbook.greensync.org/product/development/docker-compose/#injecting-your-own-dotfiles" >&2
 fi
 
+if ${CI-false}; then
+  unset GOOGLE_APPLICATION_CREDENTIALS
+fi
+
 gem list bundler -iev 2.1.0 > /dev/null || gem install bundler:2.1.0
 
 bundle check || bundle install

--- a/spec/blobby/gcs_store_spec.rb
+++ b/spec/blobby/gcs_store_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Blobby::GCSStore, integration: true do
     describe '#[]' do
       context 'with a key that exists in the bucket' do
         before(:all) do
-          @gcs_file = @gcs_store['LT05/PRE/001/001/LT50010011985144KIS00/LT50010011985144KIS00_MTL.txt']
+          @gcs_file =
+            @gcs_store['LC08/01/044/034/LC08_L1GT_044034_20130330_20170310_01_T2/LC08_L1GT_044034_20130330_20170310_01_T2_MTL.txt']
         end
 
         describe '#exists?' do


### PR DESCRIPTION
Outside of local dev use, we shouldn't be using GOOGLE_APPLICATION_CREDENTIALS anymore.

Contributes to: greensync/platform-work#356
Contributes to: greensync/platform-work#318