### PR TITLE
Add .pryrc for compatibility with pry > 0.14

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'pry-byebug'


### PR DESCRIPTION
Contributes to https://github.com/greensync/platform-work/issues/658
This doesn't strictly need to be merged until we upgrade `pry` to `>= 0.14`.